### PR TITLE
Update rubocop dependency

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop",       "0.89.0"
-  spec.add_dependency "rubocop-rails", "2.0.1"
+  spec.add_dependency "rubocop",       "0.92.0"
+  spec.add_dependency "rubocop-rails", "2.8.1"
 end
+

--- a/lib/ut/style_rails/version.rb
+++ b/lib/ut/style_rails/version.rb
@@ -3,7 +3,7 @@
 module UT
   module StyleRails
     module Version
-      VERSION = "0.0.2"
+      VERSION = "0.0.3"
     end
   end
 end


### PR DESCRIPTION
Bump the dependencies to stay up-to-date. Rubocop moves fast so we can minimize falling behind on rule name changes.