### PR TITLE
Add a rails cop configuration that was missing

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -41,4 +41,8 @@ Rails/UniqBeforePluck:
   Description: 'Prefer the use of uniq or distinct before pluck.'
   Enabled: true
 
+Rails/ActiveRecordAliases:
+  Description: 'Checks that ActiveRecord aliases are not used. The direct method names are more clear and easier to read.'
+  Enabled: true
+
 # ------------------------------------ /Rails --------------------------------------------

--- a/lib/ut/style_rails/version.rb
+++ b/lib/ut/style_rails/version.rb
@@ -3,7 +3,7 @@
 module UT
   module StyleRails
     module Version
-      VERSION = "0.0.3"
+      VERSION = "0.0.4"
     end
   end
 end


### PR DESCRIPTION
# Purpose
The rails-based rubocop configurations need to live here, so that https://github.com/usertesting/ut_rubocop can be used by non-rails ruby projects. Most of the rules removed by https://github.com/usertesting/ut_rubocop/pull/4 already existed here, but this one was missing.

# Implementation
* Add the rule from https://github.com/usertesting/ut_rubocop/pull/4/files#diff-391be63d86ca0541cef3ee2c9302c75c391f294e4e8466af9c15d19137480fd1L214-L216